### PR TITLE
Work against upstream py_zipkin >= 0.19.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,9 @@ setuptools.setup(
     author_email='darrell@swiftstack.com',
     url='https://swiftstack.com',
     packages=['swift_zipkin'],
+    install_requires=[
+        'py_zipkin>0.19.0',
+    ],
     classifiers=['Development Status :: 4 - Beta',
                  'Operating System :: POSIX :: Linux',
                  'Programming Language :: Python :: 2.7',

--- a/swift_zipkin/patcher.py
+++ b/swift_zipkin/patcher.py
@@ -36,7 +36,9 @@
 #  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 #  THE SOFTWARE.
+import py_zipkin.instrumentations.python_threads
 import py_zipkin.storage
+import py_zipkin.thread_local
 
 from swift_zipkin import api, wsgi, http, greenthread, memcached, transport
 
@@ -62,10 +64,13 @@ def patch_eventlet_and_swift(logger, zipkin_host='127.0.0.1', zipkin_port=9411,
     """
     # Overwrite py_zipkin.storage get/set_default_tracer functions with our
     # greenthread-aware functions.
-    py_zipkin.storage.set_default_tracer = api._set_greenthread_local_tracer
-    py_zipkin.storage.get_default_tracer = api._get_greenthread_local_tracer
-    py_zipkin.zipkin.get_default_tracer = api._get_greenthread_local_tracer
-    py_zipkin.get_default_tracer = api._get_greenthread_local_tracer
+    py_zipkin.storage.set_default_tracer = api.set_default_tracer
+    py_zipkin.storage.get_default_tracer = api.get_default_tracer
+    py_zipkin.storage.has_default_tracer = api.has_default_tracer
+    py_zipkin.zipkin.get_default_tracer = api.get_default_tracer
+    py_zipkin.thread_local.get_default_tracer = api.get_default_tracer
+    py_zipkin.instrumentations.python_threads.get_default_tracer = api.get_default_tracer
+    py_zipkin.get_default_tracer = api.get_default_tracer
 
     # py_zipkin uses 0-100% for sample-rate, so convert here
     api.sample_rate_pct = sample_rate * 100.0

--- a/swift_zipkin/zipkin.py
+++ b/swift_zipkin/zipkin.py
@@ -43,43 +43,16 @@
 How to Enable Zipkin Tracing in a Swift Cluster
 -----------------------------------------------
 
-XXX Rewrite this
+XXX Write this
 
-This middleware was written as an effort to refactor parts of the proxy server,
-so this functionality was already available in previous releases and every
-attempt was made to maintain backwards compatibility. To allow operators to
-perform a seamless upgrade, it is not required to add the middleware to the
-proxy pipeline and the flag ``allow_versions`` in the container server
-configuration files are still valid, but only when using
-``X-Versions-Location``. In future releases, ``allow_versions`` will be
-deprecated in favor of adding this middleware to the pipeline to enable or
-disable the feature.
-
-In case the middleware is added to the proxy pipeline, you must also
-set ``allow_versioned_writes`` to ``True`` in the middleware options
-to enable the information about this middleware to be returned in a /info
-request.
-
- .. note::
-     You need to add the middleware to the proxy pipeline and set
-     ``allow_versioned_writes = True`` to use ``X-History-Location``. Setting
-     ``allow_versions = True`` in the container server is not sufficient to
-     enable the use of ``X-History-Location``.
 
 
 ------------------------------------------------
 How to Disable Zipkin Tracing in a Swift Cluster
 ------------------------------------------------
 
-XXX Rewrite this
+XXX Write this
 
-If you want to disable all functionality, set ``allow_versioned_writes`` to
-``False`` in the middleware options.
-
-Disable versioning from a container (x is any value except empty)::
-
-    curl -i -XPOST -H "X-Auth-Token: <token>" \
--H "X-Remove-Versions-Location: x" http://<storage_url>/container
 """
 
 import os


### PR DESCRIPTION
This should preserve all the functionality we wanted wrt concurrent
sub-requests with many fewer hacks.